### PR TITLE
Improve visibility for the bakeware executable path

### DIFF
--- a/bakeware/lib/bakeware/assembler.ex
+++ b/bakeware/lib/bakeware/assembler.ex
@@ -99,11 +99,8 @@ defmodule Bakeware.Assembler do
     _ = File.rm_rf!(assembler.cpio)
     _ = File.rm_rf!(assembler.trailer)
 
-    IO.puts(
-      "Bakeware successfully assembled executable at #{
-        Path.relative_to(assembler.output, File.cwd!())
-      }"
-    )
+    IO.puts("Bakeware successfully assembled executable at\n")
+    IO.puts("    #{Path.relative_to(assembler.output, File.cwd!())}")
 
     assembler
   end

--- a/bakeware/lib/bakeware/assembler.ex
+++ b/bakeware/lib/bakeware/assembler.ex
@@ -99,7 +99,7 @@ defmodule Bakeware.Assembler do
     _ = File.rm_rf!(assembler.cpio)
     _ = File.rm_rf!(assembler.trailer)
 
-    IO.puts("Bakeware successfully assembled executable at\n")
+    IO.puts("Bakeware successfully assembled executable at:\n")
     IO.puts("    #{Path.relative_to(assembler.output, File.cwd!())}")
 
     assembler


### PR DESCRIPTION
Fixes #38 by following existing release patterns to make it feel more at home, but more importantly show the path more prominently. 

End result looks like:

```
Bakeware successfully assembled executable at: 

    _build/prod/rel/bakeware/simple_script

Release created at _build/prod/rel/simple_script!

    # To start your system
    _build/prod/rel/simple_script/bin/simple_script start

Once the release is running:

    # To connect to it remotely
    _build/prod/rel/simple_script/bin/simple_script remote

    # To stop it gracefully (you may also send SIGINT/SIGTERM)
    _build/prod/rel/simple_script/bin/simple_script stop

To list all commands:

    _build/prod/rel/simple_script/bin/simple_script
```